### PR TITLE
[#18] Spinner 컴포넌트

### DIFF
--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -56,5 +56,5 @@ const Wrapper = styled.div<SpinnerProps>`
   border-left-color: ${bgColor};
   border-radius: 100%;`;
   }}
-  animation: ${rotate} ${({ speed = '1' }) => speed}s infinite linear;
+  animation: ${rotate} ${({ speed = 1 }) => speed}s infinite linear;
 `;

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,60 @@
+import { COLORS } from '@/styles/color';
+import { SpinnerProps } from '@/types/spinner';
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const SIZE = {
+  xs: 25,
+  sm: 30,
+  md: 40,
+  lg: 50,
+};
+
+const FONT_SIZE = {
+  xs: 12,
+  sm: 20,
+  md: 30,
+  lg: 40,
+};
+
+function Spinner({ children, ...props }: SpinnerProps) {
+  return <Wrapper {...props}>{children}</Wrapper>;
+}
+
+export default Spinner;
+
+const rotate = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const Wrapper = styled.div<SpinnerProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  ${({ size = 'sm' }) => {
+    return `
+      width: ${SIZE[size]}px;
+      height: ${SIZE[size]}px;
+    `;
+  }}
+  font-size: ${({ size = 'sm' }) => FONT_SIZE[size]}px;
+  ${({
+    children,
+    thickness = 2,
+    color = COLORS.black,
+    bgColor = 'transparent',
+  }) => {
+    return children
+      ? ``
+      : `border: ${thickness}px solid
+    ${color};
+  border-left-color: ${bgColor};
+  border-radius: 100%;`;
+  }}
+  animation: ${rotate} ${({ speed = '1' }) => speed}s infinite linear;
+`;

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -47,13 +47,13 @@ const Wrapper = styled.div<SpinnerProps>`
     children,
     thickness = 2,
     color = COLORS.black,
-    bgColor = 'transparent',
+    emptyColor = 'transparent',
   }) => {
     return children
       ? ``
       : `border: ${thickness}px solid
     ${color};
-  border-left-color: ${bgColor};
+  border-left-color: ${emptyColor};
   border-radius: 100%;`;
   }}
   animation: ${rotate} ${({ speed = 1 }) => speed}s infinite linear;

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,6 +1,7 @@
 import useBoolean from '@/hooks/useBoolean';
 import { COLORS } from '@/styles/color';
-import SwitchProps from '@/types/switch';
+import { SwitchProps } from '@/types/switch';
+
 import styled from '@emotion/styled';
 
 function Switch({ onClick, ...props }: SwitchProps) {

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,5 +1,5 @@
 import useBoolean from '@/hooks/useBoolean';
-import COLORS from '@/styles/color';
+import { COLORS } from '@/styles/color';
 import SwitchProps from '@/types/switch';
 import styled from '@emotion/styled';
 

--- a/src/stories/Spinner.stories.tsx
+++ b/src/stories/Spinner.stories.tsx
@@ -1,0 +1,25 @@
+import Spinner from '@/components/Spinner';
+import { COLORS } from '@/styles/color';
+import SwitchProps from '@/types/switch';
+
+const meta = {
+  title: 'Spinner',
+  args: {
+    size: 'sm',
+    thickness: '2',
+    color: COLORS.black,
+    bgColor: 'transparent',
+    speed: '1',
+  },
+  component: Spinner,
+};
+
+export default meta;
+
+function Component({ children, ...props }: SwitchProps) {
+  return <Spinner {...props}>{children}</Spinner>;
+}
+
+export const Spinner_ = {
+  render: Component,
+};

--- a/src/stories/Spinner.stories.tsx
+++ b/src/stories/Spinner.stories.tsx
@@ -1,6 +1,6 @@
 import Spinner from '@/components/Spinner';
 import { COLORS } from '@/styles/color';
-import SwitchProps from '@/types/switch';
+import { SwitchProps } from '@/types/switch';
 
 const meta = {
   title: 'Spinner',
@@ -8,7 +8,7 @@ const meta = {
     size: 'sm',
     thickness: '2',
     color: COLORS.black,
-    bgColor: 'transparent',
+    emptyColor: 'transparent',
     speed: '1',
   },
   component: Spinner,

--- a/src/types/spinner.ts
+++ b/src/types/spinner.ts
@@ -1,0 +1,13 @@
+import { DefaultProps, SizeToken } from '@/types/default';
+import { ReactNode } from 'react';
+
+interface SpinnerProps extends DefaultProps {
+  size?: SizeToken;
+  thickness?: number;
+  color?: string;
+  bgColor?: string;
+  speed?: string;
+  children?: ReactNode;
+}
+
+export type { SpinnerProps };

--- a/src/types/spinner.ts
+++ b/src/types/spinner.ts
@@ -5,7 +5,7 @@ interface SpinnerProps extends DefaultProps {
   size?: SizeToken;
   thickness?: number;
   color?: string;
-  bgColor?: string;
+  emptyColor?: string;
   speed?: number;
   children?: ReactNode;
 }

--- a/src/types/spinner.ts
+++ b/src/types/spinner.ts
@@ -6,7 +6,7 @@ interface SpinnerProps extends DefaultProps {
   thickness?: number;
   color?: string;
   bgColor?: string;
-  speed?: string;
+  speed?: number;
   children?: ReactNode;
 }
 


### PR DESCRIPTION
## 🍞 작업 내용
- [x] Spinner 컴포넌트

## 📌 리뷰 포인트

```ts
interface SpinnerProps extends DefaultProps {
  size?: SizeToken;
  thickness?: number;
  color?: string;
  bgColor?: string;
  speed?: number;
  children?: ReactNode;
}
```

- `size` : 크기를 조절하는 props ( xs / sm / md / lg )
- `thickness` : 두께를 조절하는 props
- `color` : 스피너 색을 정하는 props
- `bgColor` : 스피너 배경색을 정하는 props
- `speed` : 스피너 속도를 조절하는 props ( 기준은 `초[s]`로 설정해뒀습니다. ) 
- `children` : 스피너를 커스텀 할 수 있는 props
  - 원래 해당 props 이름을 icon이나 custom으로 하고 싶었는데
  - children 밖에 인식을 못해서 다음과 같이 설정했습니다
  - 혹시 방법을 아시는 분은 정보 공유 부탁드립니당

## 🖼️ 스크린샷
![spinner](https://github.com/bbang-ui/bbang-ui/assets/49686619/8f788ab6-b2e3-436c-8a2c-e6d1a0a1f7b3)

