### PR TITLE
[#31] useMediaQuery

### DIFF
--- a/src/hooks/useDeviceType.ts
+++ b/src/hooks/useDeviceType.ts
@@ -1,0 +1,15 @@
+import useMediaQuery from '@/hooks/useMediaQuery';
+
+const MD = 1200;
+const SM = 767;
+
+function useDeviceType() {
+  const isTablet = useMediaQuery(
+    `(min-width: ${SM + 1}px) and (max-width: ${MD}px)`,
+  );
+
+  const isMobile = useMediaQuery(`(max-width: ${SM}px)`);
+  return { isTablet, isMobile };
+}
+
+export default useDeviceType;

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+function useMediaQuery(query: string) {
+  const getMatches = (query: string): boolean => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  };
+
+  const [matches, setMatches] = useState<boolean>(getMatches(query));
+
+  const handleChange = () => {
+    setMatches(getMatches(query));
+  };
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia(query);
+
+    handleChange();
+
+    matchMedia.addEventListener('change', handleChange);
+
+    return () => {
+      matchMedia.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+}
+export default useMediaQuery;


### PR DESCRIPTION
## 🍞 작업 내용
- [x] useMediaQuery hook
- [x] useDeviceType hook

## 📌 리뷰 포인트
`const isDesktop = useMediaQuery('(min-width: 1200px)');`
- 파라미터 안에 사용하고 싶은 `width px` 값을 넣어주면 미디어 쿼리 사용이 가능합니다.
- useDeviceType은 useMediaQuery를 보다 더 쉽게 사용하기 위해 개발했습니다.

## 🖼️ 스크린샷
https://github.com/bbang-ui/bbang-ui/assets/49686619/26259028-2fdd-4912-a889-a21a42d44b00

