### PR TITLE
[#33] useHover

### DIFF
--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -1,0 +1,17 @@
+import { RefObject, useEffect } from 'react';
+
+function useEventListener<EventType extends keyof HTMLElementEventMap>(
+  event: EventType,
+  handler: (e: HTMLElementEventMap[EventType]) => void,
+  elementRef: RefObject<HTMLElement>,
+) {
+  useEffect(() => {
+    const ref = elementRef.current;
+    if (ref) {
+      ref.addEventListener(event, handler);
+      return () => ref.removeEventListener(event, handler);
+    }
+  }, []);
+}
+
+export { useEventListener };

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -1,9 +1,10 @@
-import { RefObject, useEffect } from 'react';
+import { ElementRef } from '@/types/default';
+import { useEffect } from 'react';
 
 function useEventListener<EventType extends keyof HTMLElementEventMap>(
   event: EventType,
   handler: (e: HTMLElementEventMap[EventType]) => void,
-  elementRef: RefObject<HTMLElement>,
+  elementRef: ElementRef,
 ) {
   useEffect(() => {
     const ref = elementRef.current;

--- a/src/hooks/useHover.ts
+++ b/src/hooks/useHover.ts
@@ -1,8 +1,8 @@
 import { useEventListener } from '@/hooks/useEventListener';
-import type { RefObject } from 'react';
+import { ElementRef } from '@/types/default';
 import { useState } from 'react';
 
-function useHover(elementRef: RefObject<HTMLElement>) {
+function useHover(elementRef: ElementRef) {
   const [value, setValue] = useState(false);
 
   const handleMouseEnter = () => {

--- a/src/hooks/useHover.ts
+++ b/src/hooks/useHover.ts
@@ -5,12 +5,8 @@ import { useState } from 'react';
 function useHover(elementRef: ElementRef) {
   const [value, setValue] = useState(false);
 
-  const handleMouseEnter = () => {
-    setValue(true);
-  };
-  const handleMouseLeave = () => {
-    setValue(false);
-  };
+  const handleMouseEnter = () => setValue(true);
+  const handleMouseLeave = () => setValue(false);
 
   useEventListener('mouseenter', handleMouseEnter, elementRef);
   useEventListener('mouseleave', handleMouseLeave, elementRef);

--- a/src/hooks/useHover.ts
+++ b/src/hooks/useHover.ts
@@ -1,0 +1,21 @@
+import { useEventListener } from '@/hooks/useEventListener';
+import type { RefObject } from 'react';
+import { useState } from 'react';
+
+function useHover(elementRef: RefObject<HTMLElement>) {
+  const [value, setValue] = useState(false);
+
+  const handleMouseEnter = () => {
+    setValue(true);
+  };
+  const handleMouseLeave = () => {
+    setValue(false);
+  };
+
+  useEventListener('mouseenter', handleMouseEnter, elementRef);
+  useEventListener('mouseleave', handleMouseLeave, elementRef);
+
+  return value;
+}
+
+export { useHover };

--- a/src/types/default.ts
+++ b/src/types/default.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, ReactNode, RefObject } from 'react';
 
 interface PropsWithChildren {
   children?: ReactNode;
@@ -12,10 +12,12 @@ interface DefaultProps extends PropsWithChildren {
 type SizeToken = 'xs' | 'sm' | 'md' | 'lg';
 type ShadowToken = 'sm' | 'base' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 type ColorToken = 'primary' | 'black' | 'white';
+type ElementRef = RefObject<HTMLElement>;
 
 export type {
   ColorToken,
   DefaultProps,
+  ElementRef,
   PropsWithChildren,
   ShadowToken,
   SizeToken,


### PR DESCRIPTION
## 🍞 작업 내용
- [x] useEventListener
- [x] useHover


## 📌 리뷰 포인트
- 제네릭 타입은 잘 모르고 있던 부분이였는데, 이번 커스텀 훅들을 통해 제네릭 타입을 언제 사용해야될지 알게 된 것 같습니다.

## 사용방법
```ts
function App() {
  const divRef = useRef(null);
  const isHover = useHover(divRef);
  return <Wrapper ref={divRef}>{isHover && <div>hi</div>}</Wrapper>;
}
```

- ref 지정
- useHover 파라미터로 ref 넘겨주기

## 🖼️ 스크린샷
https://github.com/bbang-ui/bbang-ui/assets/49686619/d394e931-8c19-4856-9466-836d1d795a56